### PR TITLE
Corrected data type for age of differential correction for GGA message

### DIFF
--- a/pynmeagps/nmeatypes_get.py
+++ b/pynmeagps/nmeatypes_get.py
@@ -132,7 +132,7 @@ NMEA_PAYLOADS_GET = {
         "altUnit": CH,
         "sep": DE,
         "sepUnit": CH,
-        "diffAge": IN,
+        "diffAge": DE,
         "diffStation": IN,
     },
     "GLL": {


### PR DESCRIPTION
The data type for the age of differential corrections for GGA messages should be 'DE' (decimal) instead of 'IN' (int) to allow sub-second updates, as used for instance by ublox devices. In comparison, the GNS message definition already uses the correct type for the diffAge field.

# pynmeagps Pull Request 

## Description

The data type for the age of differential corrections for GGA messages should be 'DE' (decimal) instead of 'IN' (int) to allow sub-second updates, as used for instance by ublox devices. 

In the GNS message definition ([line 158](https://github.com/semuconsulting/pynmeagps/blob/51b270ec0b73008ef20fbbf38bc4830c69bb103a/pynmeagps/nmeatypes_get.py#L158)) this is done correctly. 
Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py`
module or using your IDE's native Python unittest integration facilities.
Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

No tests added.

## Checklist:

- [X ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [X ] I have performed a self-review of my own code.
- [X ] I have commented my code, particularly in hard-to-understand areas.
- [X ] I have made corresponding changes to the documentation.
- [X ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [X ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [X ] My changes generate no new warnings.
- [X ] Any dependent changes have been merged and published in downstream modules.
- [X ] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
