### PR TITLE
update the dmm2ddd function

### DIFF
--- a/pynmeagps/nmeahelpers.py
+++ b/pynmeagps/nmeahelpers.py
@@ -130,7 +130,7 @@ def dmm2ddd(pos: str, att: str) -> float:
     else:
         posdeg = float(pos[0:3])
         posmin = float(pos[3:])
-    return round((posdeg + posmin / 60), 6)
+    return round((posdeg + posmin / 60), 8)
 
 
 def ddd2dmm(degrees: float, att: str) -> str:


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description
Modified the decimal length of the return value of the dmm2ddd function.

When we use GNSS devices to get the location using RTK service, the accuracy can reach centimeter-level, while the accuracy of 6 decimal places is 0.11m, which will lose the positioning accuracy of GNSS devices.
So, I change it from 6 to 8.

Fixes # (issue)
none.

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
