### PR TITLE
Add Kenwood sentence PKLSH and expand gitignore to ignore .venv for c…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Pipfile*.*
 /examples/temp*.py
 /.pytest_cache/
 pylint_report.txt
+.venv

--- a/pynmeagps/nmeatypes_core.py
+++ b/pynmeagps/nmeatypes_core.py
@@ -215,6 +215,10 @@ NMEA_MSGIDS_PROP = {
     "GRMW": "Set Additional Waypoint Information",
     "GRMZ": "Altitude",
     # ***************************************************************
+    # JVCKenwood Proprietary message types
+    # ***************************************************************
+    "KLSH": "FleetSync GNSS sentence",
+    # ***************************************************************
     # U-BLOX Proprietary message types
     # ***************************************************************
     "UBX00": "PUBX-POSITION Lat/Long Position Data",

--- a/pynmeagps/nmeatypes_get.py
+++ b/pynmeagps/nmeatypes_get.py
@@ -381,6 +381,19 @@ NMEA_PAYLOADS_GET = {
         "ltzn": ST,
     },
     # *********************************************
+    # JVCKENWOOD PROPRIETARY MESSAGES
+    # *********************************************
+    "KLSH": {
+        "lat": LA,
+        "NS": CH,
+        "lon": LN,
+        "EW": CH,
+        "time": TM,
+        "status": CH,
+        "fleetId": ST,
+        "deviceId": ST,
+    },
+    # *********************************************
     # GARMIN PROPRIETARY MESSAGES
     # *********************************************
     "GRME": {  # estimated error information

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -21,6 +21,7 @@ class ParseTest(unittest.TestCase):
         self.messageGLL_HP = (
             "$GNGLL,5327.0431923,S,00214.4139641,E,223232.00,A,A*6C\r\n"
         )
+        self.messagePKLSH = "$PKLSH,3851.3330,N,09447.9417,W,012212,V,100,1202,*24\r\n"
         self.messagePUBX = "$PUBX,00,103607.00,5327.03942,N,00214.42462,W,104.461,G3,29,31,0.085,39.63,-0.007,,5.88,7.62,8.09,6,0,0*69\r\n"
         self.messagePGRMM = "$PGRMM,WGS84*26\r\n"
         self.messagePGRMO = "$PGRMO,PGRMM,2*30\r\n"
@@ -48,6 +49,13 @@ class ParseTest(unittest.TestCase):
             ),
         )
         print(res.serialize())
+
+    def testParsePKLSH(self):  # Proprietary JVCKenwood message
+        res = NMEAReader.parse(self.messagePKLSH)
+        self.assertEqual(
+            str(res),
+            "<NMEA(PKLSH, lat=38.85555, NS=N, lon=-94.7990283333, EW=W, time=, status=V, fleetId=100, deviceId=1202)>",
+        )
 
     def testParsePUBX(self):  # proprietary UBX message
         res = NMEAReader.parse(self.messagePUBX)


### PR DESCRIPTION
…onvenience.

# pynmeagps Pull Request Template

## Description

Add a Kenwood Proprietary sentence $PKLSH. Only public documentation was used to derive the structure of the sentence. 

Also, and much smaller, added .venv to .gitignore for convenience.

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

Tests were run using pytest, no failures and there is no real codecov for the additions I made as far as I can tell.

## Checklist:

- [X] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [X] I have tested my code against the full `tests/test_*.py` unittest suite.
- [X] My changes generate no new warnings.
- [X] Any dependent changes have been merged and published in downstream modules.
- [X] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
