### PR TITLE
update VALMSGID flag processing Fixes #25

### DIFF
--- a/pynmeagps/nmeareader.py
+++ b/pynmeagps/nmeareader.py
@@ -30,7 +30,7 @@ from pynmeagps.nmeahelpers import (
     calc_checksum,
     isvalid_cksum,
 )
-from pynmeagps.nmeatypes_core import NMEA_HDR, VALCKSUM
+from pynmeagps.nmeatypes_core import NMEA_HDR, VALCKSUM, VALMSGID
 
 
 class NMEAReader:
@@ -165,7 +165,7 @@ class NMEAReader:
         Parse NMEA byte stream to NMEAMessage object.
 
         :param bytes message: bytes message to parse
-        :param int validate (kwarg): bitfield validation flags - VALCKSUM (default), VALMSGID
+        :param int validate (kwarg): bitfield validation flags - VALCKSUM (default), VALMSGID (can be OR'd)
         :param int msgmode (kwarg): 0 = GET (default), 1 = SET, 2 = POLL
         :return: NMEAMessage object (or None if unknown message and VALMSGID is not set)
         :rtype: NMEAMessage
@@ -193,4 +193,6 @@ class NMEAReader:
             )
 
         except nme.NMEAMessageError as err:
+            if not validate & VALMSGID:
+                return None
             raise nme.NMEAParseError(err)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -11,7 +11,7 @@ Created on 4 Mar 2021
 
 import unittest
 
-from pynmeagps import NMEAReader, NMEAParseError, SET
+from pynmeagps import NMEAReader, NMEAParseError, SET, VALCKSUM, VALMSGID
 
 
 class ParseTest(unittest.TestCase):
@@ -79,13 +79,14 @@ class ParseTest(unittest.TestCase):
     ):  # unknown message identifier with validate (VALCKSUM + VALMSGID) - should be rejected
         EXPECTED_ERROR = "Unknown msgID GNXXX, msgmode GET."
         with self.assertRaises(NMEAParseError) as context:
-            NMEAReader.parse(self.messageNK, validate=3)
+            NMEAReader.parse(self.messageNK, validate=VALCKSUM | VALMSGID)
         self.assertTrue(EXPECTED_ERROR in str(context.exception))
 
-    # def testParseNK2(
-    #     self,
-    # ):  # unknown message identifier with validate VALCKSUM only - should just be ignored.
-    #     NMEAReader.parse(self.messageNK)
+    def testParseNK2(
+        self,
+    ):  # unknown message identifier with validate VALCKSUM only - should just be ignored.
+        res = NMEAReader.parse(self.messageNK, validate=VALCKSUM)
+        self.assertEqual(res, None)
 
     def testParseBADMODE(self):  # invalid mode setting
         EXPECTED_ERROR = "Invalid parse mode 4 - must be 0, 1 or 2."


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description

Fix NMEAReader to correctly process VALMSGID flag. If the NMEA message is valid (i.e. checksum is good) but unknown;

- `NMEAReader.parse(validate=VALMSGID)` method will raise an `NMEAParseError`
- `NMEAReader.parse(validate=0)` method will return `None`

**NB:** the VALMSGID flag is only intended to allow _valid_ but unknown NMEA messages to be ignored. If the NMEA stream message is garbage,  other parsing errors may still be raised. These can be ignored by setting the `quitonerror` flag to False.

Fixes #25 

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] additional tests added to test_parse

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
