### PR TITLE
Rc 1.0.25

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: semuadmin
 
 ---
 
-**PYNMEAGPS BUG REPORT**
+# pynmeagps Bug Report Template
 
 **NB**: Please raise any general queries in the [pynmeagps Discussions Channels](https://github.com/semuconsulting/pynmeagps/discussions) in the first instance.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,19 +11,23 @@ assignees: semuadmin
 
 ---
 
+**PYNMEAGPS BUG REPORT**
+
+**NB**: Please raise any general queries in the [pynmeagps Discussions Channels](https://github.com/semuconsulting/pynmeagps/discussions) in the first instance.
+
 **Describe the bug**
 
 A clear and concise description of what the bug is.
 
 Please specify the pynmeagps version (`>>> pynmeagps.version`) and, where possible, include:
 - The error message and full traceback.
-- A binary / hexadecimal dump of the UBX data stream (e.g. from PuTTY or screen).
+- A binary / hexadecimal dump of the incoming NMEA data stream (e.g. from PuTTY or screen).
 
 **To Reproduce**
 
 Steps to reproduce the behaviour:
 1. Any relevant device configuration (if other than factory defaults).
-2. Any causal UBX command input(s).
+2. Any causal NMEA command input(s).
 
 **Expected Behavior**
 
@@ -31,13 +35,14 @@ A clear and concise description of what you expected to happen.
 
 **Desktop (please complete the following information):**
 
-- The operating system you're using [e.g. Windows 10, MacOS Big Sur, Ubuntu Bionic]
-- The type of serial connection [e.g. USB, UART1, I2C]
+- The operating system you're using [e.g. Windows 11, MacOS Ventura, Ubuntu Lunar]
+- The version of Python you're using (e.g. Python 3.11.4)
+- The type of serial connection [e.g. USB, UART1]
 
 **GNSS/GPS Device (please complete the following information as best you can):**
 
-- Device Model/Generation: [e.g. u-blox NEO-9M]
-- Firmware Version: [e.g. SPG 4.03]
+- Device Model/Generation: [e.g. u-blox ZED-F9P]
+- Firmware Version: [e.g. HPG 1.32]
 - Protocol: [e.g. 32.00]
  
 This information is typically output by the device at startup via a series of NMEA TXT messages. 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,7 +10,7 @@ labels: ''
 assignees: semuadmin
 
 ---
-**PYNMEAGPS FEATURE REQUEST**
+# pynmeagps Feature Request Template
 
 **NB**: Please raise any feature suggestions or queries in the [pynmeagps Discussions Channels](https://github.com/semuconsulting/pynmeagps/discussions) in the first instance.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -10,6 +10,9 @@ labels: ''
 assignees: semuadmin
 
 ---
+**PYNMEAGPS FEATURE REQUEST**
+
+**NB**: Please raise any feature suggestions or queries in the [pynmeagps Discussions Channels](https://github.com/semuconsulting/pynmeagps/discussions) in the first instance.
 
 **Is your feature request related to a problem? Please describe.**
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ Fixes # (issue)
 
 ## Testing
 
-Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
+Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.
 
 - [ ] Test A
 - [ ] Test B
@@ -16,7 +16,7 @@ Please test all changes, however trivial, against the supplied pytest suite `tes
 ## Checklist:
 
 - [ ] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
-- [ ] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
+- [ ] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
 - [ ] I have performed a self-review of my own code.
 - [ ] I have commented my code, particularly in hard-to-understand areas.
 - [ ] I have made corresponding changes to the documentation.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,18 @@
 {
-    "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": false,
+    "python.testing.unittestEnabled": true,
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ],
     "python.formatting.provider": "black",
     // for Windows, assume symlink has been set up python3<==>python
     "python.defaultInterpreterPath": "python3",
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.24"
+    "moduleversion": "1.0.25",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 # pynmeagps Release Notes
 
+### RELEASE CANDIDATE 1.0.25
+
 ### RELEASE 1.0.24
 
 1. Remove Python 3.7 from workflows.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,10 @@
 
 ### RELEASE CANDIDATE 1.0.25
 
+FIXES:
+
+1. Cater for 3-digit degrees latitude value - Fixes #37
+
 ### RELEASE 1.0.24
 
 1. Remove Python 3.7 from workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "NMEA protocol parser and generator"
-version = "1.0.24"
+version = "1.0.25"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.24"
+__version__ = "1.0.25"

--- a/src/pynmeagps/nmeahelpers.py
+++ b/src/pynmeagps/nmeahelpers.py
@@ -130,12 +130,14 @@ def dmm2ddd(pos: str) -> float:
 
     :param str pos: (d)ddmm.mmmmm
     :return: pos as decimal degrees
-    :rtype: float
+    :rtype: float or str if invalid
 
     """
 
     try:
         dp = pos.find(".")
+        if dp < 4:
+            raise ValueError()
         posdeg = float(pos[0 : dp - 2])
         posmin = float(pos[dp - 2 :])
         return round((posdeg + posmin / 60), 10)

--- a/src/pynmeagps/nmeahelpers.py
+++ b/src/pynmeagps/nmeahelpers.py
@@ -124,24 +124,20 @@ def isvalid_cksum(message: object) -> bool:
     return cksum == calc_checksum(message)
 
 
-def dmm2ddd(pos: str, att: str) -> float:
+def dmm2ddd(pos: str) -> float:
     """
     Convert NMEA lat/lon string to (unsigned) decimal degrees.
 
     :param str pos: (d)ddmm.mmmmm
-    :param str att: 'LA' (lat) or 'LN' (lon)
     :return: pos as decimal degrees
     :rtype: float
 
     """
 
     try:
-        if att == LA:
-            posdeg = float(pos[0:2])
-            posmin = float(pos[2:])
-        else:
-            posdeg = float(pos[0:3])
-            posmin = float(pos[3:])
+        dp = pos.find(".")
+        posdeg = float(pos[0 : dp - 2])
+        posmin = float(pos[dp - 2 :])
         return round((posdeg + posmin / 60), 10)
     except (TypeError, ValueError):
         return ""

--- a/src/pynmeagps/nmeamessage.py
+++ b/src/pynmeagps/nmeamessage.py
@@ -457,7 +457,7 @@ class NMEAMessage:
             if vals != "":
                 val = int(vals)
         elif att in (nmt.LA, nmt.LN):  # lat/lon (d)ddmm.mmmmm(mm)
-            val = dmm2ddd(vals, att)
+            val = dmm2ddd(vals)
         elif att == nmt.TM:  # time hhmmss.ss
             val = time2utc(vals)
         else:

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -106,11 +106,15 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(res, False)
 
     def testDMM2DDD(self):
-        res = dmm2ddd("5314.12345", "LA")
+        res = dmm2ddd("5314.12345")
         self.assertEqual(res, 53.2353908333)
-        res = dmm2ddd("00214.12345", "LN")
+        res = dmm2ddd("02348.3822990")
+        self.assertEqual(res, 23.80637165)
+        res = dmm2ddd("00234.3822990")
+        self.assertEqual(res, 2.5730383167)
+        res = dmm2ddd("00214.12345")
         self.assertEqual(res, 2.2353908333)
-        res = dmm2ddd("12825.12344", "LN")
+        res = dmm2ddd("12825.12344")
         self.assertEqual(res, 128.418724)
 
     def testDDD2DMM(self):

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -116,6 +116,10 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(res, 2.2353908333)
         res = dmm2ddd("12825.12344")
         self.assertEqual(res, 128.418724)
+        res = dmm2ddd("1282512344")
+        self.assertEqual(res, "")
+        res = dmm2ddd("2345.x5678")
+        self.assertEqual(res, "")
 
     def testDDD2DMM(self):
         res = ddd2dmm(3.75000, "LA")


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description

RELEASE CANDIDATE 1.0.25

1. Add support for non-standard 3-digit degree latitude value, e.g.
`'$GNGLL,02348.3822990,S,15313.5862807,E,040856.82,A,D*5F'`
2. NB: footprint of `dmm2ddd` helper method has changed - `att` argument no longer required.

Fixes #37

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Static tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
