### PR TITLE
Rc 1.0.26

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,5 +14,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.25",
+    "moduleversion": "1.0.26",
 }

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Examples:
 ...
 ```
 
-Example - Socket input (using enhanced iterator):
+Example - Socket input (using iterator):
 
 ```python
 >>> import socket
@@ -129,7 +129,7 @@ Example - Socket input (using enhanced iterator):
 >>> stream = socket.socket(socket.AF_INET, socket.SOCK_STREAM):
 >>> stream.connect(("localhost", 50007))
 >>> nmr = NMEAReader(stream)
->>> for (raw_data, parsed_data) in nmr.iterate(): print(parsed_data)
+>>> for (raw_data, parsed_data) in nmr: print(parsed_data)
 ```
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # pynmeagps Release Notes
 
+### RELEASE CANDIDATE 1.0.26
+
+CHANGES:
+
+2. Deprecated `NMEAReader.iterate()` method removed - use the standard iterator instead e.g. `nmr = NMEAReader(stream, **wkargs): for (raw,parse) in nmr: ...`, passing any `quitonerror` or `errorhandler` kwargs to the NMEAReader constructor.
+
 ### RELEASE 1.0.25
 
 FIXES:
@@ -87,7 +93,7 @@ ENHANCEMENTS:
 CHANGES:
 
 1. `quitonerror` and `errorhandler` kwargs added to NMEAReader constructor - see Sphinx documentation for details.
-2. `NMEAReader.iterate()` method deprecated - use the standard iterator instead e.g. `nmr = NMEAReader(**wkargs): for (raw,parse) in nmr: ...`, passing any `quitonerror` or `errorhandler` kwargs to the NMEAReader constructor.
+2. `NMEAReader.iterate()` method deprecated - use the standard iterator instead e.g. `nmr = NMEAReader(stream, **wkargs): for (raw,parse) in nmr: ...`, passing any `quitonerror` or `errorhandler` kwargs to the NMEAReader constructor.
 
 ### RELEASE 1.0.19
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,8 @@
 
 CHANGES:
 
-2. Deprecated `NMEAReader.iterate()` method removed - use the standard iterator instead e.g. `nmr = NMEAReader(stream, **wkargs): for (raw,parse) in nmr: ...`, passing any `quitonerror` or `errorhandler` kwargs to the NMEAReader constructor.
+1. Deprecated `NMEAReader.iterate()` method removed - use the standard iterator instead e.g. `nmr = NMEAReader(stream, **wkargs): for (raw,parse) in nmr: ...`, passing any `quitonerror` or `errorhandler` kwargs to the NMEAReader constructor.
+1. Internal streamlining of helper methods.
 
 ### RELEASE 1.0.25
 

--- a/examples/nmeafile.py
+++ b/examples/nmeafile.py
@@ -28,10 +28,10 @@ def read(stream, errorhandler):
 
     msgcount = 0
 
-    nmr = NMEAReader(stream)
-    for (raw, parsed_data) in nmr.iterate(
-        nmeaonly=False, quitonerror=False, errorhandler=errorhandler
-    ):
+    nmr = NMEAReader(
+        stream, nmeaonly=False, quitonerror=False, errorhandler=errorhandler
+    )
+    for raw, parsed_data in nmr:
         print(parsed_data)
         msgcount += 1
 
@@ -39,7 +39,6 @@ def read(stream, errorhandler):
 
 
 if __name__ == "__main__":
-
     print("\nEnter fully qualified name of file containing raw NMEA data: ", end="")
     filename = input().strip('"')
 

--- a/examples/nmeasocket.py
+++ b/examples/nmeasocket.py
@@ -25,7 +25,7 @@ def read(stream: socket.socket):
         stream,
     )
     try:
-        for (_, parsed_data) in nmr.iterate():
+        for (_, parsed_data) in nmr:
             print(parsed_data)
             msgcount += 1
     except KeyboardInterrupt:

--- a/examples/utilities.py
+++ b/examples/utilities.py
@@ -79,7 +79,7 @@ print(
     f"\nConvert ECEF X: {X}, Y: {Y}, Z: {Z} to",
     f"geodetic using alternate {DATUM} ({ellipsoid}) datum ...",
 )
-lat, lon, height = ecef2llh(X - delta_x, Y - delta_z, Z - delta_z, a, f)
+lat, lon, height = ecef2llh(X - delta_x, Y - delta_y, Z - delta_z, a, f)
 print(f"Geodetic lat: {lat}, lon: {lon}, height: {height}")
 
 print(f"\nConvert geodetic {lat}, {lon}, {height} back to ECEF ...")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: BSD License",
     "Topic :: Utilities",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
   {name = "semuadmin", email = "semuadmin@semuconsulting.com"}
 ]
 description = "NMEA protocol parser and generator"
-version = "1.0.25"
+version = "1.0.26"
 license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.25"
+__version__ = "1.0.26"

--- a/src/pynmeagps/nmeamessage.py
+++ b/src/pynmeagps/nmeamessage.py
@@ -23,7 +23,6 @@ from pynmeagps.nmeahelpers import (
     time2str,
     dmm2ddd,
     ddd2dmm,
-    list2csv,
     calc_checksum,
 )
 
@@ -264,7 +263,8 @@ class NMEAMessage:
                     key += kwargs["msgId"]
                 else:
                     raise nme.NMEAMessageError(
-                        f"P{key} message definitions must include payload or msgId keyword arguments."
+                        f"P{key} message definitions must "
+                        + "include payload or msgId keyword arguments."
                     )
             if self._mode == nmt.POLL:
                 return nmp.NMEA_PAYLOADS_POLL[key]
@@ -354,8 +354,8 @@ class NMEAMessage:
         """
 
         output = "$" + self._talker + self._msgID + ","
-        if len(self._payload) > 0:
-            output += list2csv(self._payload)
+        for i, s in enumerate(self._payload):
+            output += ("," if i else "") + s
         output += "*" + self._checksum + "\r\n"
         return output.encode("utf-8")  # convert str to bytes
 

--- a/src/pynmeagps/nmeareader.py
+++ b/src/pynmeagps/nmeareader.py
@@ -28,7 +28,6 @@ import pynmeagps.exceptions as nme
 from pynmeagps.nmeahelpers import (
     get_parts,
     calc_checksum,
-    isvalid_cksum,
 )
 from pynmeagps.nmeatypes_core import (
     NMEA_HDR,
@@ -48,7 +47,7 @@ class NMEAReader:
         """Constructor.
 
         :param stream stream: input data stream (e.g. Serial or binary File)
-        :param int quitonerror: (kwarg) 0 = ignore errors, 1 = log errors and continue, 2 = (re)raise errors (1)
+        :param int quitonerror: (kwarg) 0 = ignore, 1 = log and continue, 2 = (re)raise (1)
         :param int errorhandler: (kwarg) error handling object or function (None)
         :param bool nmeaonly (kwarg): True = error on non-NMEA data, False = ignore non-NMEA data
         :param int validate (kwarg): bitfield validation flags - VALCKSUM (default), VALMSGID
@@ -194,7 +193,7 @@ class NMEAReader:
         Parse NMEA byte stream to NMEAMessage object.
 
         :param bytes message: bytes message to parse
-        :param int validate (kwarg): bitfield validation flags - VALCKSUM (default), VALMSGID (can be OR'd)
+        :param int validate (kwarg): 1 VALCKSUM (default), 2 VALMSGID (can be OR'd)
         :param int msgmode (kwarg): 0 = GET (default), 1 = SET, 2 = POLL
         :return: NMEAMessage object (or None if unknown message and VALMSGID is not set)
         :rtype: NMEAMessage
@@ -210,12 +209,13 @@ class NMEAReader:
             )
 
         try:
-            talker, msgid, payload, checksum = get_parts(message)
+            _, talker, msgid, payload, checksum = get_parts(message)
             if validate & VALCKSUM:
-                if not isvalid_cksum(message):
+                ccksum = calc_checksum(message)
+                if checksum != ccksum:
                     raise nme.NMEAParseError(
                         f"Message {talker}{msgid} invalid checksum {checksum}"
-                        f" - should be {calc_checksum(message)}."
+                        f" - should be {ccksum}."
                     )
             return NMEAMessage(
                 talker, msgid, msgmode, payload=payload, checksum=checksum

--- a/src/pynmeagps/nmeareader.py
+++ b/src/pynmeagps/nmeareader.py
@@ -188,23 +188,6 @@ class NMEAReader:
             else:
                 self._errorhandler(err)
 
-    def iterate(self, **kwargs) -> tuple:  # pylint: disable=unused-argument
-        """
-        DEPRECATED - WILL BE REMOVED IN VERSION >=1.2.21
-        USE STANDARD ITERATOR INSTEAD
-        Invoke the iterator within an exception handling framework.
-
-        :return: tuple of (raw_data as bytes, parsed_data as NMEAMessage)
-        :rtype: tuple
-        :raises: NMEA...Error (if quitonerror is True and stream is invalid)
-        """
-
-        while True:
-            try:
-                yield next(self)
-            except StopIteration:
-                break
-
     @staticmethod
     def parse(message: bytes, **kwargs) -> object:
         """

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -18,11 +18,8 @@ from pynmeagps import (
 )
 from pynmeagps.nmeatypes_core import GET, POLL
 from pynmeagps.nmeahelpers import (
-    int2hexstr,
     get_parts,
-    get_content,
     calc_checksum,
-    isvalid_cksum,
     deg2dmm,
     deg2dms,
     dmm2ddd,
@@ -63,17 +60,12 @@ class StaticTest(unittest.TestCase):
     # Helper methods
     # *******************************************
 
-    def testInt2Hex(self):
-        res = int2hexstr(15)
-        self.assertEqual(res, "0F")
-        res = int2hexstr(104)
-        self.assertEqual(res, "68")
-
     def testGetParts(self):
         res = get_parts(self.messageGLL)
         self.assertEqual(
             res,
             (
+                "GNGLL,5327.04319,S,00214.41396,E,223232.00,A,A",
                 "GN",
                 "GLL",
                 ["5327.04319", "S", "00214.41396", "E", "223232.00", "A", "A"],
@@ -87,23 +79,11 @@ class StaticTest(unittest.TestCase):
             get_parts(self.messageCRAP)
         self.assertTrue(EXPECTED_ERROR in str(context.exception))
 
-    def testGetContent(self):
-        res = get_content(self.messageGLL)
-        self.assertEqual(res, "GNGLL,5327.04319,S,00214.41396,E,223232.00,A,A")
-
     def testCalcChecksum(self):
         res = calc_checksum(self.messageGLL)
         self.assertEqual(res, "68")
         res = calc_checksum(self.messagePUBX)
         self.assertEqual(res, "69")
-
-    def testGoodChecksum(self):
-        res = isvalid_cksum(self.messageGLL)
-        self.assertEqual(res, True)
-
-    def testBadChecksum(self):
-        res = isvalid_cksum(self.messageBADCK)
-        self.assertEqual(res, False)
 
     def testDMM2DDD(self):
         res = dmm2ddd("5314.12345")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -284,27 +284,6 @@ class StreamTest(unittest.TestCase):
                 i += 1
         self.assertEqual(i, 8)
 
-    def testNMEAITERATE1(self):  # NMEAReader iterate() helper method
-        EXPECTED_RESULTS = (
-            "<NMEA(GNDTM, datum=W84, subDatum=, latOfset=0.0, NS=N, lonOfset=0.0, EW=E, alt=0.0, refDatum=W84)>",
-            "<NMEA(GNRMC, time=10:36:07, status=A, lat=53.450657, NS=N, lon=-2.2404103333, EW=W, spd=0.046, cog=, date=2021-03-06, mv=, mvEW=, posMode=A, navStatus=V)>",
-            "<NMEA(GNVTG, cogt=, cogtUnit=T, cogm=, cogmUnit=M, sogn=0.046, sognUnit=N, sogk=0.085, sogkUnit=K, posMode=A)>",
-            "<NMEA(GNGNS, time=10:36:07, lat=53.450657, NS=N, lon=-2.2404103333, EW=W, posMode=AANN, numSV=6, HDOP=5.88, alt=56.0, sep=48.5, diffAge=, diffStation=, navStatus=V)>",
-            "<NMEA(GNGGA, time=10:36:07, lat=53.450657, NS=N, lon=-2.2404103333, EW=W, quality=1, numSV=6, HDOP=5.88, alt=56.0, altUnit=M, sep=48.5, sepUnit=M, diffAge=, diffStation=)>",
-            "<NMEA(GNGSA, opMode=A, navMode=3, svid_01=23, svid_02=24, svid_03=20, svid_04=12, svid_05=, svid_06=, svid_07=, svid_08=, svid_09=, svid_10=, svid_11=, svid_12=, PDOP=9.62, HDOP=5.88, VDOP=7.62, systemId=1)>",
-            "<NMEA(GPGSV, numMsg=3, msgNum=1, numSV=11, svid_01=1, elv_01=6.0, az_01=14, cno_01=8, svid_02=12, elv_02=43.0, az_02=207, cno_02=28, svid_03=14, elv_03=6.0, az_03=49, cno_03=, svid_04=15, elv_04=44.0, az_04=171, cno_04=23, signalID=1)>",
-            "<NMEA(GPTHS, headt=23.34, mi=A)>",
-        )
-
-        i = 0
-        raw = 0
-        nmr = NMEAReader(self.streamNMEA4SM, nmeaonly=False)
-        for raw, parsed in nmr.iterate():
-            if raw is not None:
-                self.assertEqual(str(parsed), EXPECTED_RESULTS[i])
-                i += 1
-        self.assertEqual(i, 8)
-
     def testNMEAITERATE_ERR1(
         self,
     ):  # NMEAReader iterator with bad checksum
@@ -427,7 +406,7 @@ class StreamTest(unittest.TestCase):
         i = 0
         raw = 0
         nmr = NMEAReader(self.streamTRIMBLE, nmeaonly=False)
-        for raw, parsed in nmr.iterate():
+        for raw, parsed in nmr:
             if raw is not None:
                 print(parsed)
                 self.assertEqual(str(parsed), EXPECTED_RESULTS[i])


### PR DESCRIPTION
# pynmeagps Pull Request Template

RELEASE CANDIDATE 1.0.26

CHANGES:

1. Deprecated `NMEAReader.iterate()` method removed - use the standard iterator instead e.g. `nmr = NMEAReader(stream, **wkargs): for (raw,parse) in nmr: ...`, passing any quitonerror or errorhandler kwargs to the NMEAReader constructor.
1. Internal streamlining of helper methods.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
