### PR TITLE
Make it possible to define NMEA_HDR array in constructor

### DIFF
--- a/src/pynmeagps/nmeareader.py
+++ b/src/pynmeagps/nmeareader.py
@@ -53,6 +53,7 @@ class NMEAReader:
         quitonerror: int = ERR_LOG,
         bufsize: int = 4096,
         errorhandler: object = None,
+        nmeahdr: list[bytes] = NMEA_HDR
     ):
         """Constructor.
 
@@ -80,6 +81,7 @@ class NMEAReader:
         self._nmea_only = nmeaonly
         self._validate = validate
         self._mode = msgmode
+        self._nmeahdr = nmeahdr
 
     def __iter__(self):
         """Iterator."""
@@ -122,7 +124,7 @@ class NMEAReader:
                     continue
                 byte2 = self._read_bytes(1)  # read 2nd byte to confirm protocol
                 bytehdr = byte1 + byte2
-                if bytehdr in NMEA_HDR:  # it's a NMEA message
+                if bytehdr in self._nmeahdr:  # it's a NMEA message
                     byten = self._read_line()  # NMEA protocol is CRLF terminated
                     raw_data = bytehdr + byten
                     parsed_data = self.parse(


### PR DESCRIPTION
## Description

This makes it possible to receive e.g. INGGA messages from stream that would not work with the current NMEA_HDR e.g. [$G, $P, $B].

## Testing

Did not run testing as `pytest` started complaining and I don't have time to figure it out.

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
