### PR TITLE
Rc 1.0.32

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.0.31",
+    "moduleversion": "1.1.0",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,5 @@
     "editor.formatOnSave": true,
     "modulename": "${workspaceFolderBasename}",
     "distname": "${workspaceFolderBasename}",
-    "moduleversion": "1.1.0",
+    "moduleversion": "1.0.32",
 }

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,10 @@
 # pynmeagps Release Notes
 
-### RELEASE CANDIDATE 1.1.0
+### RELEASE CANDIDATE 1.0.32
 
 ENHANCEMENTS:
 
+1. Cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.
 
 ### RELEASE 1.0.31
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,11 @@
 # pynmeagps Release Notes
 
-### RELEASE CANDIDATE 1.0.31
+### RELEASE CANDIDATE 1.1.0
+
+ENHANCEMENTS:
+
+
+### RELEASE 1.0.31
 
 ENHANCEMENTS:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pynmeagps"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "NMEA protocol parser and generator"
-version = "1.1.0"
+version = "1.0.32"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pynmeagps"
 authors = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 maintainers = [{ name = "semuadmin", email = "semuadmin@semuconsulting.com" }]
 description = "NMEA protocol parser and generator"
-version = "1.0.31"
+version = "1.1.0"
 license = { file = "LICENSE" }
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.31"
+__version__ = "1.1.0"

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.0"
+__version__ = "1.0.32"

--- a/src/pynmeagps/nmeareader.py
+++ b/src/pynmeagps/nmeareader.py
@@ -170,7 +170,7 @@ class NMEAReader:
         """
 
         data = self._stream.readline()  # NMEA protocol is CRLF terminated
-        if data[-2:] != b"\x0d\x0a":  # EOF
+        if data[-1:] != b"\x0a":  # EOF
             raise EOFError()
         return data
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -367,9 +367,9 @@ class StreamTest(unittest.TestCase):
     def testBADEOF(self):  # stream with premature EOF - should just be tolerated
         EXPECTED_RESULTS = (
             "<NMEA(GNDTM, datum=W84, subDatum=, latOfset=0.0, NS=N, lonOfset=0.0, EW=E, alt=0.0, refDatum=W84)>",
-            "<NMEA(GNRMC, time=10:36:07, status=A, lat=53.450657, NS=N, lon=-2.24041033, EW=W, spd=0.046, cog=, date=2021-03-06, mv=, mvEW=, posMode=A, navStatus=V)>",
+            "<NMEA(GNRMC, time=10:36:07, status=A, lat=53.450657, NS=N, lon=-2.2404103333, EW=W, spd=0.046, cog=, date=2021-03-06, mv=, mvEW=, posMode=A, navStatus=V)>",
             "<NMEA(GNVTG, cogt=, cogtUnit=T, cogm=, cogmUnit=M, sogn=0.046, sognUnit=N, sogk=0.085, sogkUnit=K, posMode=A)>",
-            "<NMEA(GNGNS, time=10:36:07, lat=53.450657, NS=N, lon=-2.24041033, EW=W, posMode=AANN, numSV=6, HDOP=5.88, alt=56.0, sep=48.5, diffAge=, diffStation=, navStatus=V)>",
+            "<NMEA(GNGNS, time=10:36:07, lat=53.450657, NS=N, lon=-2.2404103333, EW=W, posMode=AANN, numSV=6, HDOP=5.88, alt=56.0, sep=48.5, diffAge=, diffStation=, navStatus=V)>",
         )
 
         i = 0
@@ -377,6 +377,7 @@ class StreamTest(unittest.TestCase):
         nmr = NMEAReader(self.streamBADEOF, nmeaonly=False)
         for raw, parsed in nmr:
             if raw is not None:
+                # print(parsed)
                 self.assertEqual(str(parsed), EXPECTED_RESULTS[i])
                 i += 1
 
@@ -409,7 +410,7 @@ class StreamTest(unittest.TestCase):
         nmr = NMEAReader(self.streamTRIMBLE, nmeaonly=False)
         for raw, parsed in nmr:
             if raw is not None:
-                print(parsed)
+                # print(parsed)
                 self.assertEqual(str(parsed), EXPECTED_RESULTS[i])
                 i += 1
         self.assertEqual(i, 20)


### PR DESCRIPTION
# pynmeagps Pull Request Template

## RELEASE CANDIDATE 1.0.32

1. pynmeagps.NMEAReader updated to cater for NMEA streams with LF (b"\x0a") rather than CRLF (b"\x0d\x0a") message terminators.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] File stream tests updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
