### PR TITLE
Rc 1.0.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ NMEAMessage('GN','GLL', 0, payload=['4307.4074073', 'S', '00259.2592593', 'E', '
 
 **NB:** Once instantiated, an `NMEAMessage` object is immutable.
 
+See [pynmeagps._usage.py](https://https://github.com/semuconsulting/pynmeagps/blob/master/examples/pynmeagps_usage.py) for further examples.
+
 ---
 ## <a name="serializing">Serializing</a>
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,7 +5,64 @@
 FIXES:
 
 1. Fix typo in Quectel PAIR650 GET message definition.
-1. Allow string type (*as well as datetime/time type*) for NMEA DT, DTL, DM and TM attribute types. TM strings must be in format "hhmmss" (or "hh:mm:ss") and DT/DTL/DM strings must be "yyyymmdd" (or "yyyy-mm-dd").
+1. Allow string type (*as well as datetime.date/time type*) for NMEA DT, DTL, DM and TM attribute constructors. TM strings must be in format "hhmmss" (or "hh:mm:ss"). DT/DTL/DM strings must be "yyyymmdd" (or "yyyy-mm-dd"). See examples below:
+
+```python
+from datetime import datetime
+
+from pynmeagps import SET, NMEAMessage
+
+# NOTE THAT LAD/NS ("N"/"S") and LND/EW ("E"/"W") attributes do not need to be explicitly
+# provided - these values will be derived from the sign of the decimal lat/lon values.
+
+# NMEA Date (DM, DT, DTL) and Time (TM) attributes can be populated in any of the following ways:
+
+# A) use formatted string types for TM and DT attributes
+msg1 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    date="2025-09-12",  # "-" delimiters are optional
+    time="12:15:34",  # ":" delimiters are optional
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-12, time=12:15:34, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,120925,121534,D*3B\r\n'
+print(msg1)
+print(msg1.serialize())
+
+# B) use datetime.date() and datetime.time() types for DT and TM attributes
+msg2 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    date=datetime(2025, 9, 12).date(),
+    time=datetime(2025, 9, 12, 12, 15, 34).time(),
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-12, time=12:15:34, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,120925,121534.00,D*15\r\n'
+print(msg2)
+print(msg2.serialize())
+
+# C) use default values
+msg3 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-18, time=14:37:20.373212, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,180925,143720.37,D*18\r\n'
+print(msg3)
+print(msg3.serialize())
+```
 
 ### RELEASE 1.0.52
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,12 @@
 # pynmeagps Release Notes
 
+### RELEASE 1.0.53
+
+FIXES:
+
+1. Fix typo in Quectel PAIR650 GET message definition.
+1. Allow string type (*as well as datetime/time type*) for NMEA DT, DTL, DM and TM attribute types. TM strings must be in format "hhmmss" (or "hh:mm:ss") and DT/DTL/DM strings must be "yyyymmdd" (or "yyyy-mm-dd").
+
 ### RELEASE 1.0.52
 
 ENHANCEMENTS

--- a/examples/pynmeagps_usage.py
+++ b/examples/pynmeagps_usage.py
@@ -1,0 +1,66 @@
+"""
+pynmeagps_usage.py
+
+Examples of pynmeagps.NMEAMessage constructors.
+
+Created on 19 Aug 2024
+
+:author: semuadmin (Steve Smith)
+:copyright: semuadmin © 2021
+:license: BSD 3-Clause
+"""
+
+from datetime import datetime
+
+from pynmeagps import SET, NMEAMessage
+
+# NOTE THAT LAD ("N"/"S") and LND ("E"/"W") attributes do not need to be explicitly
+# provided - these values will be derived from the sign of the decimal lat/lon values.
+
+# NMEA Date (DM, DT, DTL) and Time (TM) attributes can be populated in any of the following ways:
+
+# A) use formatted string types for TM and DT attributes
+msg1 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    date="2025-09-12",  # "-" delimiters are optional
+    time="12:15:34",  # ":" delimiters are optional
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-12, time=12:15:34, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,120925,121534,D*3B\r\n'
+print(msg1)
+print(msg1.serialize())
+
+# B) use datetime.date() and datetime.time() types for DT and TM attributes
+msg2 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    date=datetime(2025, 9, 12).date(),
+    time=datetime(2025, 9, 12, 12, 15, 34).time(),
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-12, time=12:15:34, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,120925,121534.00,D*15\r\n'
+print(msg2)
+print(msg2.serialize())
+
+# C) use default values
+msg3 = NMEAMessage(
+    "P",
+    "GRMI",
+    SET,
+    lat=-115.81513,
+    lon=37.23345,
+    rcvr_cmd="D",
+)
+# <NMEA(PGRMI, lat=-115.81513, NS=S, lon=37.23345, EW=E, date=2025-09-18, time=14:37:20.373212, rcvr_cmd=D)>
+# b'$PGRMI,11548.90780,S,03714.00700,E,180925,143720.37,D*18\r\n'
+print(msg3)
+print(msg3.serialize())

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.0.52"
+__version__ = "1.0.53"

--- a/src/pynmeagps/nmeamessage.py
+++ b/src/pynmeagps/nmeamessage.py
@@ -702,9 +702,31 @@ class NMEAMessage:
         elif att in (nmt.LA, nmt.LN):
             vals = ddd2dmm(val, att, hpmode)
         elif att == nmt.TM:
-            vals = time2str(val)
-        elif att in (nmt.DT, nmt.DTL, nmt.DM):
-            vals = date2str(val, att)
+            if isinstance(val, str):
+                vals = str(val.replace(":", ""))
+            else:  # time
+                vals = time2str(val)
+        elif att == nmt.DT:
+            if isinstance(val, str):
+                # yyyymmdd -> ddmmyy
+                val = val.replace("-", "")
+                vals = f"{val[6:8]}{val[4:6]}{val[2:4]}"
+            else:  # datetime
+                vals = date2str(val, att)
+        elif att == nmt.DTL:
+            # yyyymmdd -> ddmmyyyy
+            if isinstance(val, str):
+                val = val.replace("-", "")
+                vals = f"{val[6:8]}{val[4:6]}{val[0:4]}"
+            else:  # datetime
+                vals = date2str(val, att)
+        elif att == nmt.DM:
+            # yyyymmdd -> mmddyy
+            if isinstance(val, str):
+                val = val.replace("-", "")
+                vals = f"{val[4:6]}{val[6:8]}{val[2:4]}"
+            else:  # datetime
+                vals = date2str(val, att)
         else:
             raise nme.NMEATypeError(f"Unknown attribute type {att}.")
         return vals

--- a/src/pynmeagps/nmeatypes_core.py
+++ b/src/pynmeagps/nmeatypes_core.py
@@ -464,11 +464,11 @@ NMEA_MSGIDS_PROP = {
     "AIRSPF": "Jamming status L1",
     "AIRSPF5": "Jamming status L5",
     "QTMBKP": "Set Backup Mode",
-    "QTMCFGAIC": "Sets/gets the AIC (Active Interference Cancellation) Function",
+    "QTMCFGAIC": "Sets/Gets AIC Function",
     "QTMCFGCNST": "Sets/Gets Constellation Configuration",
     "QTMCFGFIXRATE": "Sets/Gets Fix Interval",
     "QTMCFGGEOFENCE": "Sets/Gets Geofence Feature",
-    "QTMCFGMSGRATE": "Sets/Gets Message Output Rate on Current Interface",
+    "QTMCFGMSGRATE": "Sets/Gets Message Output Rate",
     "QTMCFGNAVMODE": "Sets/Gets Navigation Mode",
     "QTMCFGNMEADP": "Sets/Gets NMEA Precision",
     "QTMCFGNMEATID": "Sets/Gets NMEA Talker ID",
@@ -524,13 +524,13 @@ NMEA_MSGIDS_PROP = {
     # ***************************************************************
     # U-BLOX Proprietary message types
     # ***************************************************************
-    "UBX00": "PUBX-POSITION Lat/Long Position Data",
-    "UBX03": "PUBX-SVSTATUS Satellite Status",
-    "UBX04": "PUBX-TIME Time of Day and Clock Information",
+    "UBX00": "Lat/Long Position Data",
+    "UBX03": "Satellite Status",
+    "UBX04": "Time of Day and Clock Information",
     "UBX05": "Lat/Long Position Data",
     "UBX06": "Lat/Long Position Data",
-    "UBX40": "Set NMEA message output rate",
-    "UBX41": "PUBX-CONFIG Set Protocols and Baudrate",
+    "UBX40": "Set NMEA Message Output Rate",
+    "UBX41": "Set Protocols and Baudrate",
     # ***************************************************************
     # Trimble Proprietary message types
     # ***************************************************************

--- a/src/pynmeagps/nmeatypes_get_prop.py
+++ b/src/pynmeagps/nmeatypes_get_prop.py
@@ -1037,6 +1037,9 @@ NMEA_PAYLOADS_GET_PROP = {
         "enabled": IN,
     },
     "AIR437": {"enabled": IN},
+    "AIR650": {
+        "second": IN,
+    },
     "AIR865": {
         "baudrate": IN,
     },

--- a/src/pynmeagps/nmeatypes_set_prop.py
+++ b/src/pynmeagps/nmeatypes_set_prop.py
@@ -31,88 +31,6 @@ from pynmeagps.nmeatypes_core import CH, DE, DT, HX, IN, LA, LAD, LN, LND, QS, S
 from pynmeagps.nmeatypes_get_prop import NMEA_PAYLOADS_GET_PROP
 
 NMEA_PAYLOADS_SET_PROP = {
-    # *********************************************
-    # GARMIN PROPRIETARY MESSAGES
-    # *********************************************
-    "GRMI": {  # sensor initialisation information
-        "lat": LA,
-        "NS": LAD,
-        "lon": LN,
-        "EW": LND,
-        "date": DT,
-        "time": TM,
-        "rcvr_cmd": CH,
-    },
-    "GRMC": {  # sensor configuration information
-        "fix": CH,
-        "alt": DE,
-        "dtm": ST,
-        "smAxis": DE,
-        "iffac": DE,
-        "xecc": DE,
-        "yecc": DE,
-        "zecc": DE,
-        "diff": CH,
-        "baudRate": IN,
-        "vfilt": IN,
-        "reserved1": ST,
-        "reserved2": ST,
-        "drtime": IN,
-    },
-    "GRMC1": {  # additional sensor configuration information
-        "nmeatim": IN,
-        "bphase": IN,
-        "autopos": IN,
-        "dgpsfr": DE,
-        "dgpsbr": IN,
-        "dgpssc": IN,
-        "nmeaver": IN,
-        "dgpsmod": CH,
-        "pwrsave": CH,
-        "attran": IN,
-        "autopwr": IN,
-        "extpwr": IN,
-    },
-    "GRMO": {  # output sentence enable
-        "msgId": ST,
-        "tgtmode": IN,
-    },
-    "GRMW": {  # additional waypoint information
-        "wptId": ST,
-        "alt": DE,
-        "symnum": HX,
-        "comment": ST,
-    },
-    # ***************************************************************
-    # Locosys Proprietary Messages SET
-    # https://www.locosystech.com/Templates/att/LS2303x-UDG_datasheet_v0.6.pdf?lng=en
-    # ***************************************************************
-    "LSC": {
-        "msgType": ST,  # e.g. "SLOPE", "MEMS", "ATTIT", "VER"
-        "value": IN,  # e.g. 0 (not present if msgType == "VER")
-    },
-    "INVCRES": {
-        "value": IN,  # 0 = clear data
-    },
-    "INVCSTR": {
-        "value": IN,  # 14 = start session
-    },
-    "INVMSLOPE": {
-        "status": IN,  # 0 = disable, 1 =  enable
-    },
-    # Proprietary Locosys command sets not yet implemented, e.g.
-    # Perform a Cold start $PMTK103*30
-    # Perform a Warm start $PMTK102*31
-    # Perform a Hot start $PMTK101*32
-    # Perform a Full Cold start $PMTK104*37
-    # Disable GLL message $PMTK314,0,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0*29
-    # Disable GSV message $PMTK314,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29
-    # Disable GLL & GSV message $PMTK314,0,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28
-    # Factory default output message $PMTK314,-1*04
-    # Navigate with GPS+GALILEO $PMTK353,1,0,1,0,0*2B
-    # Navigate with GPS+GLONASS+GALILEO $PMTK353,1,1,1,0,0*2A
-    # Navigate with GPS+BEIDOU $PMTK353,1,0,0,0,1*2B
-    # Entering Standby Mode1 $PMTK161,0*28
     # ***************************************************************
     # Quectel LC29H / LC79H Proprietary SET message types
     # https://www.quectel.com/download/quectel_lc29hlc79h_series_gnss_protocol_specification_v1-5/
@@ -206,6 +124,88 @@ NMEA_PAYLOADS_SET_PROP = {
         "portType": IN,  # 0 = UART
         "portIndex": IN,  # 0 = UART1
         "flowControl": IN,
+    },
+    # *********************************************
+    # GARMIN PROPRIETARY MESSAGES
+    # *********************************************
+    "GRMI": {  # sensor initialisation information
+        "lat": LA,
+        "NS": LAD,
+        "lon": LN,
+        "EW": LND,
+        "date": DT,
+        "time": TM,
+        "rcvr_cmd": CH,
+    },
+    "GRMC": {  # sensor configuration information
+        "fix": CH,
+        "alt": DE,
+        "dtm": ST,
+        "smAxis": DE,
+        "iffac": DE,
+        "xecc": DE,
+        "yecc": DE,
+        "zecc": DE,
+        "diff": CH,
+        "baudRate": IN,
+        "vfilt": IN,
+        "reserved1": ST,
+        "reserved2": ST,
+        "drtime": IN,
+    },
+    "GRMC1": {  # additional sensor configuration information
+        "nmeatim": IN,
+        "bphase": IN,
+        "autopos": IN,
+        "dgpsfr": DE,
+        "dgpsbr": IN,
+        "dgpssc": IN,
+        "nmeaver": IN,
+        "dgpsmod": CH,
+        "pwrsave": CH,
+        "attran": IN,
+        "autopwr": IN,
+        "extpwr": IN,
+    },
+    "GRMO": {  # output sentence enable
+        "msgId": ST,
+        "tgtmode": IN,
+    },
+    "GRMW": {  # additional waypoint information
+        "wptId": ST,
+        "alt": DE,
+        "symnum": HX,
+        "comment": ST,
+    },
+    # ***************************************************************
+    # Locosys Proprietary Messages SET
+    # https://www.locosystech.com/Templates/att/LS2303x-UDG_datasheet_v0.6.pdf?lng=en
+    # ***************************************************************
+    # Proprietary Locosys command sets not yet implemented, e.g.
+    # Perform a Cold start $PMTK103*30
+    # Perform a Warm start $PMTK102*31
+    # Perform a Hot start $PMTK101*32
+    # Perform a Full Cold start $PMTK104*37
+    # Disable GLL message $PMTK314,0,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0*29
+    # Disable GSV message $PMTK314,1,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0*29
+    # Disable GLL & GSV message $PMTK314,0,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0*28
+    # Factory default output message $PMTK314,-1*04
+    # Navigate with GPS+GALILEO $PMTK353,1,0,1,0,0*2B
+    # Navigate with GPS+GLONASS+GALILEO $PMTK353,1,1,1,0,0*2A
+    # Navigate with GPS+BEIDOU $PMTK353,1,0,0,0,1*2B
+    # Entering Standby Mode1 $PMTK161,0*28
+    "INVCRES": {
+        "value": IN,  # 0 = clear data
+    },
+    "INVCSTR": {
+        "value": IN,  # 14 = start session
+    },
+    "INVMSLOPE": {
+        "status": IN,  # 0 = disable, 1 =  enable
+    },
+    "LSC": {
+        "msgType": ST,  # e.g. "SLOPE", "MEMS", "ATTIT", "VER"
+        "value": IN,  # e.g. 0 (not present if msgType == "VER")
     },
     # ***************************************************************
     # Quectel LG290P Proprietary message types

--- a/tests/test_constructor.py
+++ b/tests/test_constructor.py
@@ -71,7 +71,7 @@ class FillTest(unittest.TestCase):
 
     def testFill_GNGLL_SP(self):  # test GET constructor in standard precision mode
         EXPECTED_RESULT = "<NMEA(GNGLL, lat=43.123456789, NS=N, lon=-2.987654321, EW=W, time=22:32:32, status=A, posMode=A)>"
-        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "W", "", "A", "A"]
+        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "W", "223232", "A", "A"]
         res = NMEAMessage(
             "GN",
             "GLL",
@@ -90,7 +90,7 @@ class FillTest(unittest.TestCase):
         self,
     ):  # derive lat/lon sign from NS/EW values
         EXPECTED_RESULT = "<NMEA(GNGLL, lat=-43.123456789, NS=S, lon=-2.987654321, EW=W, time=22:32:32, status=A, posMode=A)>"
-        EXPECTED_PAYLOAD = ["4307.40741", "S", "00259.25926", "W", "", "A", "A"]
+        EXPECTED_PAYLOAD = ["4307.40741", "S", "00259.25926", "W", "223232", "A", "A"]
         res = NMEAMessage(
             "GN",
             "GLL",
@@ -109,7 +109,7 @@ class FillTest(unittest.TestCase):
         self,
     ):  # derive lat/lon sign from NS/EW values
         EXPECTED_RESULT = "<NMEA(GNGLL, lat=43.123456789, NS=N, lon=2.987654321, EW=E, time=22:32:32, status=A, posMode=A)>"
-        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "E", "", "A", "A"]
+        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "E", "223232", "A", "A"]
         res = NMEAMessage(
             "GN",
             "GLL",
@@ -128,7 +128,7 @@ class FillTest(unittest.TestCase):
         self,
     ):  # derive lat/lon sign from NS/EW values
         EXPECTED_RESULT = "<NMEA(GNGLL, lat=43.123456789, NS=N, lon=-2.987654321, EW=W, time=22:32:32, status=A, posMode=A)>"
-        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "W", "", "A", "A"]
+        EXPECTED_PAYLOAD = ["4307.40741", "N", "00259.25926", "W", "223232", "A", "A"]
         res = NMEAMessage(
             "GN",
             "GLL",
@@ -139,6 +139,32 @@ class FillTest(unittest.TestCase):
             status="A",
             posMode="A",
             hpnmeamode=0,
+        )
+        self.assertEqual(str(res), EXPECTED_RESULT)
+        self.assertEqual(res.payload, EXPECTED_PAYLOAD)
+
+    def testFill_GRMI(
+        self,
+    ):  # test population ot TM and DT attributes by strings
+        EXPECTED_RESULT = "<NMEA(PGRMI, lat=43.123456789, NS=N, lon=-2.987654321, EW=W, date=2025-09-18, time=22:32:32, rcvr_cmd=D)>"
+        EXPECTED_PAYLOAD = [
+            "4307.40741",
+            "N",
+            "00259.25926",
+            "W",
+            "180925",
+            "223232",
+            "D",
+        ]
+        res = NMEAMessage(
+            "P",
+            "GRMI",
+            SET,
+            lat=43.123456789,
+            lon=-2.987654321,
+            date="2025-09-18",
+            time="22:32:32",
+            rcvr_cmd="D",
         )
         self.assertEqual(str(res), EXPECTED_RESULT)
         self.assertEqual(res.payload, EXPECTED_PAYLOAD)

--- a/tests/test_quectel.py
+++ b/tests/test_quectel.py
@@ -696,7 +696,7 @@ class QuectelStreamTest(unittest.TestCase):
             "<NMEA(PAIR001, commandid=437, result=0)>",
             "<NMEA(PAIR437, enabled=1)>",
             "<NMEA(PAIR001, commandid=650, result=0)>",
-            "<NMEA(PAIR650, field_01=0)>",
+            "<NMEA(PAIR650, second=0)>",
             "<NMEA(PAIR001, commandid=752, result=0)>",
             "<NMEA(PAIR001, commandid=864, result=0)>",
             "<NMEA(PAIR001, commandid=865, result=0)>",

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -264,7 +264,7 @@ class StaticTest(unittest.TestCase):
         res = msgdesc("GGA")
         self.assertEqual(res, "Global positioning system fix data")
         res = msgdesc("UBX03")
-        self.assertEqual(res, "PUBX-SVSTATUS Satellite Status")
+        self.assertEqual(res, "Satellite Status")
         res = msgdesc("XXX")
         self.assertEqual(res, "Unknown msgID XXX")
 


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description

FIXES:

1. Fix typo in Quectel PAIR650 GET message definition.
1. Allow string type (*as well as datetime.date/time type*) for NMEA DT, DTL, DM and TM attribute constructors. TM strings must be in format "hhmmss" (or "hh:mm:ss"). DT/DTL/DM strings must be "yyyymmdd" (or "yyyy-mm-dd"). See examples in /examples/pynmeagps_usage.py:

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] test_constructors.py updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
