### PR TITLE
RC 1.1.1

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,15 @@
 {
-    // pynmeagps VSCode workflow.
-    //
     // These test, build and deploy tasks are targeted at a venv
     // called 'pygpsclient' located in the user's home directory.
     // Set your workspace default VSCode Python interpreter to
     // this venv, i.e.
     // "${userHome}/pygpsclient/bin/python3" on linux/macos
-    // "C:/Users/user/pygpsclient/Scripts/python.exe" on windows
-    "python.testing.pytestEnabled": true,
+    // "${userHome}/pygpsclient/Scripts/python" on windows
+    "python.testing.pytestEnabled": false,
     "python.terminal.activateEnvironment": true,
     "editor.formatOnSave": true,
-    "modulename": "pynmeagps",
-    "distname": "pynmeagps",
+    "modulename": "${workspaceFolderBasename}",
+    "distname": "${workspaceFolderBasename}",
     "venv": "${userHome}/pygpsclient",
     "python.testing.pytestArgs": [
         "tests"
@@ -24,9 +22,13 @@
     "python.analysis.addHoverSummaries": false,
     "python-envs.defaultEnvManager": "ms-python.python:venv",
     "python-envs.pythonProjects": [],
-    "python.venvPath": "${userHome}/pygpsclient/bin/python3",
-    "python.systemPath": "/usr/local/bin/python3.14",
     "python.defaultInterpreterPath": "${userHome}/pygpsclient/bin/python3",
-    //"python.defaultInterpreterPath": "C:/Users/steve/pygpsclient/Scripts/python.exe",
-    "python.testing.unittestEnabled": false
+    "python.testing.unittestEnabled": true,
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./tests",
+        "-p",
+        "test_*.py"
+    ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -195,7 +195,7 @@
                     "pip",
                     "install",
                     "--force-reinstall",
-                    "${workspaceFolder}/dist/pynmeagps-1.0.57-py3-none-any.whl",
+                    "${workspaceFolder}/dist/pyneamgps-1.1.1-py3-none-any.whl",
                 ]
             },
             "problemMatcher": [],
@@ -211,7 +211,7 @@
             "problemMatcher": [],
             "dependsOrder": "sequence",
             "dependsOn": [
-                //"Activate Venv",
+                "Activate Venv",
                 "Build",
                 "Install", // have to install before running pylint
                 "Pylint",
@@ -275,15 +275,18 @@
             "problemMatcher": []
         },
         {
-            "label": "Run Installed Version",
+            "label": "Run from Source",
             "type": "shell",
-            "command": "${config:python.defaultInterpreterPath}",
+            "command": "python3",
             "args": [
                 "-m",
                 "pygpsclient",
                 //"--verbosity",
                 //"3"
             ],
+            "options": {
+                "cwd": "${workspaceFolder}/src"
+            },
             "problemMatcher": []
         },
     ]

--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ b'$EIGNQ,RMC*24\r\n'
  - `bearing` - finds bearing in degrees between two sets of (lat, lon) coordinates
  - `area` - finds spherical area bounded by two sets of (lat, lon) coordinates
  - `leapsecond` - find GPS UTC leapsecond offset for a given effective date
+ - `utc2wnotow` - converts UTC datetime to GPS WNO (week number), TOW (time of week in milliseconds) and Leapsecond offset
+ - `wnotow2utc` - converts GPS WNO, TOW and Leapsecond offset to UTC datetime
 
 See [Sphinx documentation](https://www.semuconsulting.com/pynmeagps/pynmeagps.html#module-pynmeagaps.nmeahelpers) for details.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # pynmeagps Release Notes
 
+### RELEASE 1.1.1
+
+1. Add helper methods `utc2wnotow` and `wnotow2utc` to convert between UTC datetime and GPS week number, time of week (in milliseconds) and leapsecond offset.
+1. Helper methods `leapsecond` and `get_gpswnotow` will now accept timezone-aware or timezone-naive datetimes. If naive, UTC will be inferred.
+
 ### RELEASE 1.1.0
 
 1. Add support for Unicore extended NMEA sentences:

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"

--- a/src/pynmeagps/nmeahelpers.py
+++ b/src/pynmeagps/nmeahelpers.py
@@ -12,8 +12,9 @@ Created on 04 Mar 2021
 # pylint: disable=invalid-name
 
 import re
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from math import acos, asin, atan2, cos, pi, sin, sqrt
+from types import NoneType
 from typing import Literal
 
 import pynmeagps.exceptions as nme
@@ -32,7 +33,7 @@ from pynmeagps.nmeatypes_core import (
 )
 
 KNOTSCONV = {"MS": 0.5144447324, "FS": 1.68781084, "MPH": 1.15078, "KMPH": 1.852001}
-LEAPS0 = datetime(1900, 1, 1, 0, 0, 0)
+LEAPS0 = datetime(1900, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
 LEAPSECONDS = [
     (2272060800, 10),  # 1 Jan 1972
     (2287785600, 11),  # 1 Jul 1972
@@ -414,21 +415,24 @@ def generate_checksum(talker: str, msgID: str, payload: list) -> str:
     return calc_checksum(content)
 
 
-def get_gpswnotow(dat: datetime) -> tuple:
+def get_gpswnotow(dat: datetime) -> tuple[int, int]:
     """
     Get GPS Week number (Wno) and Time of Week (Tow)
-    for midnight on given date.
+    for midnight on given UTC date. If supplied date
+    is timezone-naive, UTC will be inferred.
 
     GPS Epoch 0 = 6th Jan 1980
 
     :param datetime dat: calendar date
-    :return: tuple of (Wno, Tow)
-    :rtype: tuple
+    :return: wno, tow in seconds
+    :rtype: tuple[int, int]
     """
 
-    wno = int((dat - GPSEPOCH0).days / 7)
-    tow = ((dat.weekday() + 1) % 7) * 86400
-    return wno, tow
+    if dat.tzinfo is None:
+        dat = dat.replace(tzinfo=timezone.utc)
+
+    wno, tow, _ = utc2wnotow(dat)
+    return wno, int(tow / 1000)
 
 
 def get_parts(message: object) -> tuple:
@@ -572,16 +576,20 @@ def latlon2dms(lat: float, lon: float) -> tuple[str, str]:
 def leapsecond(dat: datetime) -> int:
     """
     Get GPS UTC leapsecond offset effective at date.
+    If supplied datetime is timezone naive, UTC will be inferred.
 
     Refer to LEAPSECONDS constant.
 
-    - LEAPS0 = 1900-01-01 00:00:00
-    - GPSEPOCH0 = 1980-01-06: 00:00:00
+    - LEAPS0 = 1900-01-01 00:00:00 UTC
+    - GPSEPOCH0 = 1980-01-06: 00:00:00 UTC
 
     :param datetime.datetime dat: effective date
     :return: leapsecond offset
     :rtype: int
     """
+
+    if dat.tzinfo is None:
+        dat = dat.replace(tzinfo=timezone.utc)
 
     def totsec(dt) -> int:
         return (dt - LEAPS0).total_seconds()
@@ -727,3 +735,51 @@ def time2utc(times: str) -> datetime.time:
         return utc.time()
     except (TypeError, ValueError):
         return ""
+
+
+def utc2wnotow(utc: datetime | NoneType = None) -> tuple[int, int, int]:
+    """
+    Get GPS Week number (wno), Time of Week (tow) in milliseconds
+    and leapsecond offset for given UTC datetime. If datetime is None,
+    will default to current datetime.
+
+    GPS Epoch 0 = 6th Jan 1980
+
+    :param datetime | NoneType utc: UTC datetime
+    :return: wno, tow, leapsecond
+    :rtype: tuple[int, int, int]
+    """
+
+    if utc is None:
+        utc = datetime.now(tz=timezone.utc)
+    if utc.tzinfo is None:
+        utc = utc.replace(tzinfo=timezone.utc)
+
+    ls = leapsecond(utc)
+    ts = ((utc - GPSEPOCH0).total_seconds() + ls) * 1000
+    wno = int((utc - GPSEPOCH0).days / 7)
+    tow = int(ts - wno * 604800000)
+    return wno, tow, ls
+
+
+def wnotow2utc(wno: int, tow: int, ls: int | NoneType = None) -> datetime:
+    """
+    Get UTC datetime from GPS Week number (wno), Time of Week (tow)
+    in milliseconds and leapsecond offset. If leapsecond is None, it
+    will default to the leapsecond offset applicable on the given date.
+
+    GPS Epoch 0 = 6th Jan 1980
+
+    :param int wno: week number
+    :param int tow: time of week in ms
+    :param int ls: leapsecond offset
+    :return: datetime
+    :rtype: datetime
+    """
+
+    utc = GPSEPOCH0 + timedelta(days=wno * 7)
+    utc += timedelta(milliseconds=tow)
+    if ls is None:
+        ls = leapsecond(utc)
+    utc -= timedelta(seconds=ls)
+    return utc

--- a/src/pynmeagps/nmeamessage.py
+++ b/src/pynmeagps/nmeamessage.py
@@ -14,7 +14,7 @@ import struct
 from datetime import datetime, timezone
 from logging import getLogger
 from types import NoneType
-from typing import Literal
+from typing import Any, Literal
 
 import pynmeagps.exceptions as nme
 import pynmeagps.nmeatypes_core as nmt
@@ -513,7 +513,9 @@ class NMEAMessage:
                 key += "_ALT"
         return key
 
-    def _get_dict_stmdrsenmsg(self, key: str, mode: int, **kwargs) -> str:
+    def _get_dict_stmdrsenmsg(
+        self, key: str, mode: int, **kwargs
+    ) -> str:  # pylint: disable=unused-argument
         """
         Get payload dictionary for proprietary Quectel PSTMDRSENMSG variants.
 
@@ -697,18 +699,18 @@ class NMEAMessage:
         return self._payload
 
     @property
-    def checksum(self) -> str:
+    def checksum(self) -> str | NoneType:
         """
         Checksum getter.
 
         :return: checksum as hex string
-        :rtype: str
+        :rtype: str | NoneType
         """
 
         return self._checksum
 
     @staticmethod
-    def str2val(vals: str, att: str) -> object:
+    def str2val(vals: str, att: str) -> Any:
         """
         Convert NMEA string to typed value
         (this is the format that will be available to end users).
@@ -716,7 +718,7 @@ class NMEAMessage:
         :param str vals: attribute value in NMEA protocol format
         :param str att: attribute type e.g. 'DE'
         :return: attribute value
-        :rtype: object
+        :rtype: Any
         :raises: MMEATypeError
         """
 
@@ -797,14 +799,14 @@ class NMEAMessage:
         return vals
 
     @staticmethod
-    def nomval(att: str, msgmode: int = nmt.GET) -> object:
+    def nomval(att: str, msgmode: int = nmt.GET) -> Any:
         """
         Return nominal value for specified attribute type
 
         :param str att: attribute type e.g. 'DE'
         :param int msgmode: message mode GET/SET/POLL
         :return: nominal value for type
-        :rtype: object
+        :rtype: Any
         :raises: NMEATypeError
         """
 

--- a/src/pynmeagps/nmeatypes_core.py
+++ b/src/pynmeagps/nmeatypes_core.py
@@ -12,7 +12,7 @@ has been collated from public domain sources.
 
 # pylint: disable=fixme
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 INPUT = 1
 """Input message type"""
@@ -65,7 +65,8 @@ ENCODE_COMPRESS = 4
 ENCODE_DEFLATE = 8
 """deflate socket encoding"""
 
-GPSEPOCH0 = datetime(1980, 1, 6)
+# GPSEPOCH0 = datetime(1980, 1, 6)
+GPSEPOCH0 = datetime(1980, 1, 6, tzinfo=timezone.utc)
 """GPS epoch base date"""
 # Geodetic datum spheroid values:
 # WGS84, ETRS89, EPSG4326

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -8,7 +8,7 @@ Created on 3 Oct 2020
 :author: semuadmin (Steve Smith)
 """
 
-import datetime
+from datetime import datetime, timezone, date, time
 import os
 import unittest
 
@@ -52,6 +52,8 @@ from pynmeagps.nmeahelpers import (
     time2str,
     time2utc,
     leapsecond,
+    utc2wnotow,
+    wnotow2utc,
 )
 from pynmeagps.nmeatypes_core import GET, POLL
 from pynmeagps.nmeatypes_decodes import (
@@ -213,30 +215,30 @@ class StaticTest(unittest.TestCase):
         res = date2utc("")
         self.assertEqual(res, "")
         res = date2utc("120320")
-        self.assertEqual(res, datetime.date(2020, 3, 12))
+        self.assertEqual(res, date(2020, 3, 12))
         res = date2utc("031220", "DM")
-        self.assertEqual(res, datetime.date(2020, 3, 12))
+        self.assertEqual(res, date(2020, 3, 12))
         res = date2utc("12032020", "DTL")
-        self.assertEqual(res, datetime.date(2020, 3, 12))
+        self.assertEqual(res, date(2020, 3, 12))
 
     def testTime2UTC(self):
         res = time2utc("")
         self.assertEqual(res, "")
         res = time2utc("081123.000")
-        self.assertEqual(res, datetime.time(8, 11, 23))
+        self.assertEqual(res, time(8, 11, 23))
 
     def testTime2str(self):
-        res = time2str(datetime.time(8, 11, 23))
+        res = time2str(time(8, 11, 23))
         self.assertEqual(res, "081123.00")
         res = time2str("wsdfasdf")
         self.assertEqual(res, "")
 
     def testDate2str(self):
-        res = date2str(datetime.date(2021, 3, 7))
+        res = date2str(date(2021, 3, 7))
         self.assertEqual(res, "070321")
-        res = date2str(datetime.date(2021, 3, 7), "DTL")
+        res = date2str(date(2021, 3, 7), "DTL")
         self.assertEqual(res, "07032021")
-        res = date2str(datetime.date(2021, 3, 7), "DM")
+        res = date2str(date(2021, 3, 7), "DM")
         self.assertEqual(res, "030721")
         res = date2str("wsdfasdf")
         self.assertEqual(res, "")
@@ -388,9 +390,9 @@ class StaticTest(unittest.TestCase):
         res = NMEAMessage.nomval("DE")
         self.assertEqual(res, 0.0)
         res = NMEAMessage.nomval("TM")
-        self.assertIsInstance(res, datetime.time)
+        self.assertIsInstance(res, time)
         res = NMEAMessage.nomval("DT")
-        self.assertIsInstance(res, datetime.date)
+        self.assertIsInstance(res, date)
 
     def testNomValBAD(self):
         EXPECTED_ERROR = "Unknown attribute type XX."
@@ -412,17 +414,17 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(res, "5530.00000")
         res = NMEAMessage.val2str(2.75, "LN")
         self.assertEqual(res, "00245.00000")
-        res = NMEAMessage.val2str(datetime.datetime(2021, 5, 7, 2, 45, 23), "TM")
+        res = NMEAMessage.val2str(datetime(2021, 5, 7, 2, 45, 23), "TM")
         self.assertEqual(res, "024523.00")
-        res = NMEAMessage.val2str(datetime.datetime(2020, 6, 7, 3, 27, 24), "DT")
+        res = NMEAMessage.val2str(datetime(2020, 6, 7, 3, 27, 24), "DT")
         self.assertEqual(res, "070620")
-        res = NMEAMessage.val2str(datetime.datetime(2020, 6, 7, 3, 27, 24), "DTL")
+        res = NMEAMessage.val2str(datetime(2020, 6, 7, 3, 27, 24), "DTL")
         self.assertEqual(res, "07062020")
         res = NMEAMessage.val2str("2020-06-07", "DTL")
         self.assertEqual(res, "07062020")
         res = NMEAMessage.val2str("20210708", "DTL")
         self.assertEqual(res, "08072021")
-        res = NMEAMessage.val2str(datetime.datetime(2020, 6, 7, 3, 27, 24), "DM")
+        res = NMEAMessage.val2str(datetime(2020, 6, 7, 3, 27, 24), "DM")
         self.assertEqual(res, "060720")
         res = NMEAMessage.val2str("2020-06-07", "DM")
         self.assertEqual(res, "060720")
@@ -593,16 +595,16 @@ class StaticTest(unittest.TestCase):
             (2023, 5, 27),
         ]
         vals = [
-            (2243, 0),
-            (1347, 518400),
-            (2119, 345600),
-            (1784, 0),
-            (2263, 0),
-            (2263, 518400),
+            (2243, 18),
+            (1347, 518413),
+            (2119, 345618),
+            (1784, 16),
+            (2263, 18),
+            (2263, 518418),
         ]
         for i, dat in enumerate(dats):
             y, m, d = dat
-            self.assertEqual(get_gpswnotow(datetime.datetime(y, m, d)), vals[i])
+            self.assertEqual(get_gpswnotow(datetime(y, m, d)), vals[i])
 
     def testhex2str(self):
         hex = 0x1234ABCD
@@ -622,11 +624,12 @@ class StaticTest(unittest.TestCase):
 
     def testleapsecond(self):
         self.assertEqual(leapsecond(GPSEPOCH0), 0)
-        self.assertEqual(leapsecond(datetime.datetime(1985, 1, 1, 0, 0, 0)), 3)
-        self.assertEqual(leapsecond(datetime.datetime(1997, 8, 1, 0, 0, 0)), 12)
-        self.assertEqual(leapsecond(datetime.datetime(2025, 9, 18, 16, 51, 34)), 18)
-        self.assertEqual(leapsecond(datetime.datetime(1974, 9, 18, 16, 51, 34)), -6)
-        self.assertEqual(leapsecond(datetime.datetime(1971, 9, 18, 16, 51, 34)), 0)
+        self.assertEqual(leapsecond(datetime(1985, 1, 1, 0, 0, 0)), 3)
+        self.assertEqual(leapsecond(datetime(1997, 8, 1, 0, 0, 0)), 12)
+        self.assertEqual(leapsecond(datetime(2025, 9, 18, 16, 51, 34)), 18)
+        self.assertEqual(leapsecond(datetime(2025, 9, 18, 16, 51, 34, tzinfo=timezone.utc)), 18)
+        self.assertEqual(leapsecond(datetime(1974, 9, 18, 16, 51, 34)), -6)
+        self.assertEqual(leapsecond(datetime(1971, 9, 18, 16, 51, 34)), 0)
 
     def testmaxidx(self):
         PYLD1 = {"svid_01": 7, "svid_02": 8, "elv_03": 15, "svid_04": 23}
@@ -637,6 +640,27 @@ class StaticTest(unittest.TestCase):
         self.assertEqual(groupsize(**PYLD3), 0)
         PYLD4 = {}
         self.assertEqual(groupsize(**PYLD4), 0)
+
+    def testutc2wnotow(self):
+        dat = datetime(2026, 2, 20, 23, 21, 36, 123000, tzinfo=timezone.utc)
+        wno, tow, ls = utc2wnotow(dat)
+        # print(wno, tow, ls)
+        self.assertEqual((wno, tow), (2406, 516114123))
+        dat = datetime(2026, 2, 20, 23, 21, 36, 123000)
+        wno, tow, ls = utc2wnotow(dat)
+        # print(wno, tow, ls)
+        self.assertEqual((wno, tow), (2406, 516114123))
+        wno, tow, ls = utc2wnotow()
+        # print(wno, tow, ls)
+        self.assertIsInstance(wno, int)
+        self.assertIsInstance(tow, int)
+        self.assertIsInstance(ls, int)
+
+    def testwnotow2utc(self):
+        utc = wnotow2utc(2406,516114123,18)
+        self.assertEqual(utc, datetime(2026, 2, 20, 23, 21, 36, 123000, tzinfo=timezone.utc))
+        utc = wnotow2utc(2406,516114000)
+        self.assertEqual((utc.year, utc.month, utc.day, utc.hour), (2026, 2, 20, 23))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description

1. Add helper methods `utc2wnotow` and `wnotow2utc` to convert between UTC datetime and GPS week number, time of week (in milliseconds) and leapsecond offset.
1. Helper methods `leapsecond` and `get_gpswnotow` will now accept timezone-aware or timezone-naive datetimes. If naive, UTC will be inferred.

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] test_static.py updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
