### PR TITLE
RC 1.1.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # pynmeagps Release Notes
 
+### RELEASE 1.1.4
+
+1. Add `modwno` boolean argument to wnotow2utc and utc2wnotow helper functions - True => modular week number, False => continuous week number. The default is True (modular week no).
+
 ### RELEASE 1.1.3
 
 1. Update wnotow2utc, utc2wnotow and leapsecond helper functions to accommodate all GNSS time systems. wnotow2utc method also adds an 'autoroll' argument which, if True, will automatically roll forward modular GNSS week numbers to the latest date less than the current date - see API docs for details.

--- a/src/pynmeagps/_version.py
+++ b/src/pynmeagps/_version.py
@@ -8,4 +8,4 @@ Created on 4 Mar 2021
 :license: BSD 3-Clause
 """
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"

--- a/src/pynmeagps/nmeahelpers.py
+++ b/src/pynmeagps/nmeahelpers.py
@@ -734,6 +734,7 @@ def time2utc(times: str) -> datetime | str:
 def utc2wnotow(
     utc: datetime | NoneType = None,
     gnss: Literal["G", "E", "C", "J", "I"] = GPS,
+    modwno: bool = True,
 ) -> tuple[int, int, int]:
     """
     Get Week number (wno), Time of Week (tow) in milliseconds
@@ -748,6 +749,7 @@ def utc2wnotow(
     :param datetime | NoneType utc: UTC epoch
     :param Literal["G","E","C","J","I"] = GPS) gnss: \
         GNSS time system (GPS)
+    :param bool modwno: True = modular wno, False = continuous wno
     :return: wno, tow, leapsecond
     :rtype: tuple[int, int, int]
     """
@@ -773,8 +775,9 @@ def utc2wnotow(
     ls = 0 if gnss == GLO else leapsecond(utc, gnss)
     ts = ((utc - ep0).total_seconds() + ls) * 1000
     wno = floor((utc - ep0).days / 7)
+    wno = wno % rollover if modwno else wno
     tow = int(ts - wno * 604800000)
-    return wno % rollover, tow, ls
+    return wno, tow, ls
 
 
 def wnotow2utc(
@@ -783,6 +786,7 @@ def wnotow2utc(
     ls: int | NoneType = None,
     gnss: Literal["G", "E", "C", "J", "I"] = GPS,
     autoroll: bool = False,
+    modwno: bool = True,
 ) -> datetime:
     """
     Convert week number and seconds of week (expressed as
@@ -815,6 +819,7 @@ def wnotow2utc(
     :param int | NoneType ls: leapsecond offset (will be derived if None) (None)
     :param Literal["G","E","C","J","I"] = GPS) gnss: GNSS time system (GPS)
     :param bool autoroll: automatic rollover (False)
+    :param bool modwno: True = modular wno, False = continuous wno
     :return: GNSS epoch as UTC datetime
     :rtype: datetime
     """
@@ -831,7 +836,7 @@ def wnotow2utc(
     else:
         ep0 = EPOCH0_GPS
         rollover = 1024
-    wno %= rollover
+    wno = wno % rollover if modwno else wno
     tow %= 604800000
     current = datetime.now(timezone.utc)
     i = 0

--- a/src/pynmeagps/nmeahelpers.py
+++ b/src/pynmeagps/nmeahelpers.py
@@ -775,9 +775,9 @@ def utc2wnotow(
     ls = 0 if gnss == GLO else leapsecond(utc, gnss)
     ts = ((utc - ep0).total_seconds() + ls) * 1000
     wno = floor((utc - ep0).days / 7)
-    wno = wno % rollover if modwno else wno
+    wnom = wno % rollover
     tow = int(ts - wno * 604800000)
-    return wno, tow, ls
+    return wnom if modwno else wno, tow, ls
 
 
 def wnotow2utc(

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -631,10 +631,15 @@ class StaticTest(unittest.TestCase):
     #     self.assertIsInstance(ls, int)
 
     def testwnotow2utcGPS(self):
-        res = wnotow2utc(2406, 516114123, None)
+        res = wnotow2utc(2406, 516114123, None, GPS,False, True)
         # print(res)
         self.assertEqual(
             res, datetime(1986, 11, 21, 23, 21, 50, 123000, tzinfo=timezone.utc)
+        )
+        res = wnotow2utc(2406, 516114123, None,GPS,False, False)
+        # print(res)
+        self.assertEqual(
+            res, datetime(2026, 2, 20, 23, 21, 36, 123000, tzinfo=timezone.utc)
         )
         utc = wnotow2utc(2406, 516114000)
         self.assertEqual(
@@ -657,11 +662,17 @@ class StaticTest(unittest.TestCase):
         res = wnotow2utc(1390, 381600000, None, GAL, False)
         # print(res)
         self.assertEqual(str(res), "2026-04-16 09:59:42+00:00")
+        res = wnotow2utc(1390, 381600000, None, GAL, False, False)
+        # print(res)
+        self.assertEqual(str(res), "2026-04-16 09:59:42+00:00")
     
     def testwnotow2utcIRN(self):
         res = wnotow2utc(1390, 381600000, None, IRN, False)
         # print(res)
         self.assertEqual(str(res), "2006-08-31 09:59:46+00:00")
+        res = wnotow2utc(1390, 381600000, None, IRN, False, False)
+        # print(res)
+        self.assertEqual(str(res), "2026-04-16 09:59:42+00:00")
 
     def testleapsecondGPS(self):
         self.assertEqual(leapsecond(EPOCH0_GPS, "G"), 0)

--- a/tests/test_static.py
+++ b/tests/test_static.py
@@ -631,12 +631,12 @@ class StaticTest(unittest.TestCase):
     #     self.assertIsInstance(ls, int)
 
     def testwnotow2utcGPS(self):
-        res = wnotow2utc(2406, 516114123, None, GPS,False, True)
+        res = wnotow2utc(2406, 516114123, None, GPS, False, True)
         # print(res)
         self.assertEqual(
             res, datetime(1986, 11, 21, 23, 21, 50, 123000, tzinfo=timezone.utc)
         )
-        res = wnotow2utc(2406, 516114123, None,GPS,False, False)
+        res = wnotow2utc(2406, 516114123, None, GPS, False, False)
         # print(res)
         self.assertEqual(
             res, datetime(2026, 2, 20, 23, 21, 36, 123000, tzinfo=timezone.utc)
@@ -652,12 +652,12 @@ class StaticTest(unittest.TestCase):
         res = wnotow2utc(1390, 381600000, None, GPS, False)
         # print(res)
         self.assertEqual(str(res), "1987-01-15 09:59:56+00:00")
-    
+
     def testwnotow2utcBDS(self):
         res = wnotow2utc(1390, 381600000, None, BDS, False)
         # print(res)
         self.assertEqual(str(res), "2032-08-26 09:59:56+00:00")
-    
+
     def testwnotow2utcGAL(self):
         res = wnotow2utc(1390, 381600000, None, GAL, False)
         # print(res)
@@ -665,7 +665,7 @@ class StaticTest(unittest.TestCase):
         res = wnotow2utc(1390, 381600000, None, GAL, False, False)
         # print(res)
         self.assertEqual(str(res), "2026-04-16 09:59:42+00:00")
-    
+
     def testwnotow2utcIRN(self):
         res = wnotow2utc(1390, 381600000, None, IRN, False)
         # print(res)
@@ -711,6 +711,14 @@ class StaticTest(unittest.TestCase):
                 utc = wnotow2utc(wno, tow, None, gnss)
                 wno2, tow2, ls = utc2wnotow(utc, gnss)
                 self.assertEqual((wno, tow), (wno2, tow2))
+
+    def testutc2wnotow(self):
+
+        wno, tow, ls = utc2wnotow()
+        # print(wno, tow, ls)
+        wno, tow, ls = utc2wnotow(datetime(2026, 4, 1, 2, 3, 4))
+        # print(wno, tow, ls)
+        self.assertEqual((wno, tow, ls), (364, 266602000, 18))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# pynmeagps Pull Request Template

## Description

1. Add `modwno` boolean argument to wnotow2utc and utc2wnotow helper functions - True => modular week number, False => continuous week number. The default is True (modular week no).

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] test_static.py updated

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pynmeagps/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](https://github.com/semuconsulting/pynmeagps/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
